### PR TITLE
docs: fix README contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,9 @@ Steps:
 
 ---
 
-## Contibutors
-- **[Shubhangi Roy](https://github.com/ShubhangiRoy12)** – Project Lead & Machine Learning Engineer 
+## Contributors
+- **[Shubhangi Roy](https://github.com/ShubhangiRoy12)** - Project Lead and Machine Learning Engineer
+- **[Om Roy](https://github.com/omroy07)** - Web Developer and Machine Learning Engineer
 
-- **[Om Roy](https://github.com/omroy07)** – Web Developer  & Machine Learning Engineer
-
-
-📜 License
+## License
 This project is licensed under the MIT License. See LICENSE file for details.
-
-


### PR DESCRIPTION
## Summary
- fix the misspelled README contributors heading
- clean up contributor role formatting for the existing project contributors
- turn the trailing license line into a proper README section heading

Closes #122

## Testing
- Not run (documentation-only change)