### PR TITLE
ci: add repository integrity check

### DIFF
--- a/.github/workflows/repo-integrity.yml
+++ b/.github/workflows/repo-integrity.yml
@@ -1,0 +1,68 @@
+name: Repository Integrity Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify-repository-integrity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify expected project files still exist
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_paths=(
+            "README.md"
+            "index.html"
+            "main.html"
+            "services.html"
+            "about.html"
+            "contact.html"
+            "script.js"
+            "styles.css"
+            "transport.css"
+            "Shipments/shipments.html"
+            "Routes/route.html"
+            "Vehicles/vechicle.html"
+            "Schedule/schedule.html"
+            "Chatbot/index.html"
+            "Public transportation/index.html"
+          )
+
+          missing_paths=()
+          for path in "${required_paths[@]}"; do
+            if [[ ! -e "$path" ]]; then
+              missing_paths+=("$path")
+            fi
+          done
+
+          if (( ${#missing_paths[@]} > 0 )); then
+            echo "The repository is missing expected paths:"
+            printf ' - %s\n' "${missing_paths[@]}"
+            exit 1
+          fi
+
+      - name: Verify repository was not reduced to an unexpectedly small file set
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          file_count="$(find . -type f \
+            -not -path './.git/*' \
+            -not -path './node_modules/*' \
+            -not -path './dist/*' | wc -l)"
+
+          echo "Detected file count: $file_count"
+
+          if (( file_count < 25 )); then
+            echo "Repository file count is suspiciously low. Expected at least 25 files."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that verifies core project files and feature entry points still exist
- fail CI if the repository is reduced to a suspiciously small file set, guarding against accidental destructive merges
- address the underlying risk behind issue #137, since the codebase is already present again on current main

Closes #137

## Testing
- Not run locally (workflow executes in GitHub Actions)