### PR TITLE
feat: add website theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
               <line x1="21" y1="21" x2="16.65" y2="16.65" />
             </svg></button>
         </div>
+        <button id="theme-toggle" class="theme-toggle-btn" type="button" aria-pressed="false">Light mode</button>
         <div class="auth-divider"></div>
         <a href="#" onclick="openLoginPopup()" class="btn-text">Login</a>
         <a href="#" onclick="openSignupPopup()" class="btn-header-cta">Sign Up</a>
@@ -587,6 +588,38 @@
         setTimeout(() => el.classList.add('loaded'), i * 200);
       });
     });
+
+    (function () {
+      const toggle = document.getElementById('theme-toggle');
+      const storageKey = 'moovit-theme';
+      const lightClass = 'theme-light';
+
+      function applyTheme(theme) {
+        if (theme === 'light') document.documentElement.classList.add(lightClass);
+        else document.documentElement.classList.remove(lightClass);
+
+        if (toggle) {
+          const isLight = theme === 'light';
+          toggle.textContent = isLight ? 'Dark mode' : 'Light mode';
+          toggle.setAttribute('aria-pressed', String(isLight));
+        }
+      }
+
+      let theme = localStorage.getItem(storageKey);
+      if (!theme) {
+        theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      }
+
+      applyTheme(theme);
+
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const next = document.documentElement.classList.contains(lightClass) ? 'dark' : 'light';
+          localStorage.setItem(storageKey, next);
+          applyTheme(next);
+        });
+      }
+    })();
   </script>
 </body>
 

--- a/services.html
+++ b/services.html
@@ -37,6 +37,26 @@
             min-height: 100vh;
             line-height: 1.6;
             color: var(--gray-800);
+            transition: background 240ms ease, color 240ms ease, border-color 240ms ease;
+        }
+
+        html.theme-light {
+            --primary-blue: #0b1f3a;
+            --secondary-blue: #174ea6;
+            --accent-orange: #f97316;
+            --accent-green: #059669;
+            --accent-purple: #6d28d9;
+            --light-bg: #ffffff;
+            --white: #ffffff;
+            --gray-100: #f3f4f6;
+            --gray-200: #e6eef8;
+            --gray-600: #334155;
+            --gray-800: #0f172a;
+        }
+
+        html.theme-light body {
+            background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+            color: var(--gray-800);
         }
 
         /* Header */
@@ -110,6 +130,32 @@
             color: white;
             transform: translateY(-2px);
             box-shadow: var(--shadow-medium);
+        }
+
+        .theme-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.6rem 0.9rem;
+            border-radius: 12px;
+            border: 2px solid transparent;
+            background: var(--white);
+            color: var(--gray-600);
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.22s ease;
+        }
+
+        .theme-toggle:hover {
+            background: var(--accent-orange);
+            color: white;
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-medium);
+        }
+
+        .theme-toggle:focus {
+            outline: none;
+            box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.12);
         }
 
         /* Main Container */
@@ -524,6 +570,9 @@
                     <i class="fas fa-home"></i>
                     Home
                 </a>
+                <button id="theme-toggle" class="theme-toggle" type="button" aria-pressed="false">
+                    Light mode
+                </button>
                 <a href="index.html">
                     <i class="fas fa-sign-out-alt"></i>
                     Go Back
@@ -859,6 +908,39 @@
             </div>
         </div>
     </footer>
+    <script>
+        (function () {
+            const toggle = document.getElementById('theme-toggle');
+            const storageKey = 'moovit-theme';
+            const lightClass = 'theme-light';
+
+            function applyTheme(theme) {
+                if (theme === 'light') document.documentElement.classList.add(lightClass);
+                else document.documentElement.classList.remove(lightClass);
+
+                if (toggle) {
+                    const isLight = theme === 'light';
+                    toggle.textContent = isLight ? 'Dark mode' : 'Light mode';
+                    toggle.setAttribute('aria-pressed', String(isLight));
+                }
+            }
+
+            let theme = localStorage.getItem(storageKey);
+            if (!theme) {
+                theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+            }
+
+            applyTheme(theme);
+
+            if (toggle) {
+                toggle.addEventListener('click', function () {
+                    const next = document.documentElement.classList.contains(lightClass) ? 'dark' : 'light';
+                    localStorage.setItem(storageKey, next);
+                    applyTheme(next);
+                });
+            }
+        })();
+    </script>
 </body>
 
 </html>

--- a/transport.css
+++ b/transport.css
@@ -16,6 +16,15 @@
       --glass-border: rgba(255, 255, 255, 0.2);
     }
 
+    html.theme-light {
+      --primary: #0b1f3a;
+      --primary-light: #174ea6;
+      --secondary: #2563eb;
+      --accent: #f59e0b;
+      --glass: rgba(255, 255, 255, 0.8);
+      --glass-border: rgba(15, 23, 42, 0.08);
+    }
+
     body {
       margin: 0;
       font-family: 'Inter', sans-serif;
@@ -34,6 +43,12 @@
       color: #e2e8f0;
       min-height: 100vh;
       overflow-x: hidden;
+    }
+
+    html.theme-light body {
+      background: linear-gradient(rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.9)),
+        url('https://images.pexels.com/photos/1637438/pexels-photo-1637438.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2');
+      color: #0f172a;
     }
 
     /* --- Cursor Styles --- */
@@ -227,6 +242,91 @@
       box-shadow: 0 8px 20px rgba(37, 99, 235, 0.6);
     }
 
+    .theme-toggle-btn {
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      color: white;
+      padding: 8px 14px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.3s ease;
+    }
+
+    .theme-toggle-btn:hover {
+      transform: translateY(-1px);
+      background: rgba(255, 255, 255, 0.14);
+    }
+
+    html.theme-light .theme-toggle-btn {
+      background: rgba(255, 255, 255, 0.88);
+      border-color: rgba(15, 23, 42, 0.1);
+      color: #0f172a;
+    }
+
+    html.theme-light .modern-header {
+      background: rgba(248, 250, 252, 0.35);
+    }
+
+    html.theme-light .modern-header.scrolled {
+      background: rgba(248, 250, 252, 0.88);
+      border-bottom-color: rgba(15, 23, 42, 0.08);
+      box-shadow: 0 4px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    html.theme-light .brand-logo,
+    html.theme-light .nav-link,
+    html.theme-light .btn-text {
+      color: #0f172a;
+    }
+
+    html.theme-light .search-bar-mini {
+      background: rgba(255, 255, 255, 0.88);
+      border-color: rgba(15, 23, 42, 0.08);
+    }
+
+    html.theme-light .search-bar-mini input,
+    html.theme-light .search-bar-mini button {
+      color: #334155;
+    }
+
+    html.theme-light .hero,
+    html.theme-light .card,
+    html.theme-light footer {
+      border-color: rgba(15, 23, 42, 0.08);
+      box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+    }
+
+    html.theme-light .hero h2,
+    html.theme-light .card h2,
+    html.theme-light .services-title,
+    html.theme-light .footer-container h3,
+    html.theme-light .footer-container h4 {
+      color: #0f172a;
+      -webkit-text-fill-color: initial;
+      text-shadow: none;
+    }
+
+    html.theme-light .hero p,
+    html.theme-light .card p,
+    html.theme-light .footer-container a,
+    html.theme-light .footer-bottom,
+    html.theme-light .footer-social p {
+      color: #475569;
+    }
+
+    html.theme-light .tracking-wrapper input,
+    html.theme-light .newsletter-form input,
+    html.theme-light .form-group input {
+      background: rgba(255, 255, 255, 0.96);
+      color: #0f172a;
+    }
+
+    html.theme-light footer {
+      background: rgba(248, 250, 252, 0.88);
+    }
+
     /* Mobile Menu */
     .mobile-toggle {
       display: none;
@@ -295,7 +395,8 @@
       .search-bar-mini,
       .auth-divider,
       .btn-text,
-      .btn-header-cta {
+      .btn-header-cta,
+      .theme-toggle-btn {
         display: none;
       }
 


### PR DESCRIPTION
## Summary
- add persistent light/dark theme toggles to the landing page and services page
- reuse the same localStorage theme key already used by the dashboard so the preference stays consistent across pages
- add light-theme styling to the shared transport UI so the public-facing website now supports theme switching too

Closes #163

## Testing
- Not run (UI change; needs browser verification)