### PR TITLE
fix: add camera error recovery and loading state to live detection

### DIFF
--- a/live-detection/live-detection.css
+++ b/live-detection/live-detection.css
@@ -79,6 +79,7 @@ main {
     border-radius: 10px;
     overflow: hidden;
     margin-bottom: 1rem;
+    background-color: #1a1a2e;
 }
 
 #video,
@@ -102,4 +103,92 @@ footer {
     text-align: center;
     padding: 1rem;
     box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Camera error state */
+#camera-error {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #1a1a2e;
+    color: #e0e0e0;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    z-index: 10;
+}
+
+#camera-error .error-icon {
+    font-size: 2.5rem;
+    color: #ef5350;
+    margin-bottom: 0.5rem;
+}
+
+#camera-error h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.1rem;
+    color: #ffffff;
+}
+
+#camera-error p {
+    margin: 0 0 1rem 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    max-width: 400px;
+    color: #b0b0b0;
+}
+
+#retry-btn {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 0.5rem 1.5rem;
+    border-radius: 6px;
+    font-family: var(--font-family);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+#retry-btn:hover {
+    background-color: #388E3C;
+}
+
+/* Loading state */
+#loading-indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #1a1a2e;
+    color: #b0b0b0;
+    z-index: 10;
+}
+
+#loading-indicator p {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+}
+
+.spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid rgba(255, 255, 255, 0.15);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
 }

--- a/live-detection/live-detection.html
+++ b/live-detection/live-detection.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="../favicon.png">
   <title>Live Object Detection</title>
   <link rel="stylesheet" href="live-detection.css">
@@ -15,8 +16,8 @@
 
 <body>
   <header>
-    <h1>Live Object Detection 🔍</h1>
-    <a href="C:\\Users\\Konda Reddy\\OneDrive\\Desktop\\MooVit\\main.html" class="btn btn-light">← Home</a>
+    <h1>Live Object Detection</h1>
+    <a href="../main.html" class="btn btn-light">Home</a>
   </header>
 
   <main>

--- a/live-detection/live-detection.js
+++ b/live-detection/live-detection.js
@@ -5,13 +5,26 @@ const wrapper = document.getElementById('wrapper');
 let lastSpoken = {};
 const speakDelay = 4000; // Delay between speaking the same label (ms)
 
+// Cache the model so retries don't re-download it.
+let cachedModel = null;
+
+// Guard flag to prevent overlapping start() calls.
+let isStarting = false;
+
+// Track the active stream so we can stop it on retry.
+let activeStream = null;
+
 function showError(type) {
-    // Remove any existing error message
+    // Remove any existing error message.
     const old = document.getElementById('camera-error');
     if (old) old.remove();
 
     const box = document.createElement('div');
     box.id = 'camera-error';
+
+    // Accessibility: let screen readers announce this error.
+    box.setAttribute('role', 'alert');
+    box.setAttribute('aria-live', 'assertive');
 
     let heading = 'Camera unavailable';
     let message = 'Something went wrong while accessing your camera.';
@@ -45,6 +58,8 @@ function showLoading() {
 
     const el = document.createElement('div');
     el.id = 'loading-indicator';
+    el.setAttribute('role', 'status');
+    el.setAttribute('aria-live', 'polite');
     el.innerHTML =
         '<div class="spinner"></div>' +
         '<p>Loading detection model...</p>';
@@ -57,24 +72,55 @@ function hideLoading() {
     if (el) el.remove();
 }
 
+function stopActiveStream() {
+    // Stop all tracks on the existing stream to free the camera.
+    if (activeStream) {
+        activeStream.getTracks().forEach(function(track) {
+            track.stop();
+        });
+        activeStream = null;
+    }
+    video.srcObject = null;
+}
+
 function retryCamera() {
+    // Prevent spamming the retry button.
+    if (isStarting) return;
+
     const errorBox = document.getElementById('camera-error');
     if (errorBox) errorBox.remove();
     start();
 }
 
 async function start() {
+    // Block concurrent calls.
+    if (isStarting) return;
+    isStarting = true;
+
+    // Release any previous camera stream before requesting a new one.
+    stopActiveStream();
+
     showLoading();
 
-    // Load the COCO-SSD model first.
-    let model;
-    try {
-        model = await cocoSsd.load();
-    } catch (err) {
-        console.error('Model load failed:', err);
+    // Check for secure context before even trying the camera.
+    if (window.isSecureContext === false) {
         hideLoading();
-        showError('model');
+        isStarting = false;
+        showError('insecure');
         return;
+    }
+
+    // Load the COCO-SSD model, or reuse the cached one.
+    if (!cachedModel) {
+        try {
+            cachedModel = await cocoSsd.load();
+        } catch (err) {
+            console.error('Model load failed:', err);
+            hideLoading();
+            isStarting = false;
+            showError('model');
+            return;
+        }
     }
 
     // Request camera access.
@@ -84,12 +130,14 @@ async function start() {
     } catch (err) {
         console.error('Camera error:', err);
         hideLoading();
+        isStarting = false;
 
         if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
             showError('denied');
         } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
             showError('not-found');
-        } else if (err.name === 'NotSupportedError') {
+        } else if (err.name === 'NotSupportedError' || err.name === 'SecurityError') {
+            // Some browsers throw SecurityError instead of NotSupportedError.
             showError('insecure');
         } else {
             showError('generic');
@@ -97,8 +145,12 @@ async function start() {
         return;
     }
 
+    activeStream = stream;
     hideLoading();
+    isStarting = false;
     video.srcObject = stream;
+
+    const model = cachedModel;
 
     video.onloadedmetadata = () => {
         // Set the canvas dimensions to match the video.

--- a/live-detection/live-detection.js
+++ b/live-detection/live-detection.js
@@ -1,15 +1,103 @@
 const video = document.getElementById('video');
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
+const wrapper = document.getElementById('wrapper');
 let lastSpoken = {};
 const speakDelay = 4000; // Delay between speaking the same label (ms)
 
-async function start() {
-    // Load the COCO-SSD model.
-    const model = await cocoSsd.load();
+function showError(type) {
+    // Remove any existing error message
+    const old = document.getElementById('camera-error');
+    if (old) old.remove();
 
-    // Request access to the user's webcam.
-    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const box = document.createElement('div');
+    box.id = 'camera-error';
+
+    let heading = 'Camera unavailable';
+    let message = 'Something went wrong while accessing your camera.';
+
+    if (type === 'denied') {
+        heading = 'Camera access denied';
+        message = 'You blocked camera permission. To use live detection, allow camera access in your browser settings and try again.';
+    } else if (type === 'not-found') {
+        heading = 'No camera found';
+        message = 'This device does not appear to have a camera, or it is being used by another application.';
+    } else if (type === 'insecure') {
+        heading = 'HTTPS required';
+        message = 'Camera access requires a secure connection. Open this page using HTTPS instead of HTTP.';
+    } else if (type === 'model') {
+        heading = 'Detection model failed to load';
+        message = 'The object detection model could not be downloaded. Check your internet connection and try again.';
+    }
+
+    box.innerHTML =
+        '<div class="error-icon">&#9888;</div>' +
+        '<h3>' + heading + '</h3>' +
+        '<p>' + message + '</p>' +
+        '<button id="retry-btn" onclick="retryCamera()">Try again</button>';
+
+    wrapper.appendChild(box);
+}
+
+function showLoading() {
+    const old = document.getElementById('loading-indicator');
+    if (old) old.remove();
+
+    const el = document.createElement('div');
+    el.id = 'loading-indicator';
+    el.innerHTML =
+        '<div class="spinner"></div>' +
+        '<p>Loading detection model...</p>';
+
+    wrapper.appendChild(el);
+}
+
+function hideLoading() {
+    const el = document.getElementById('loading-indicator');
+    if (el) el.remove();
+}
+
+function retryCamera() {
+    const errorBox = document.getElementById('camera-error');
+    if (errorBox) errorBox.remove();
+    start();
+}
+
+async function start() {
+    showLoading();
+
+    // Load the COCO-SSD model first.
+    let model;
+    try {
+        model = await cocoSsd.load();
+    } catch (err) {
+        console.error('Model load failed:', err);
+        hideLoading();
+        showError('model');
+        return;
+    }
+
+    // Request camera access.
+    let stream;
+    try {
+        stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    } catch (err) {
+        console.error('Camera error:', err);
+        hideLoading();
+
+        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
+            showError('denied');
+        } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
+            showError('not-found');
+        } else if (err.name === 'NotSupportedError') {
+            showError('insecure');
+        } else {
+            showError('generic');
+        }
+        return;
+    }
+
+    hideLoading();
     video.srcObject = stream;
 
     video.onloadedmetadata = () => {
@@ -77,8 +165,5 @@ async function start() {
     }
 }
 
-// Start the application and handle any errors.
-start().catch(err => {
-    console.error(err);
-    alert('Webcam or model error: ' + err.message);
-});
+// Start the application.
+start();


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #379 

## Rationale for this change

The live detection page uses `alert()` for all camera errors and leaves users on a dead page with no recovery path. Since MooVit is built for visually impaired users, silent failures on the detection page are a real usability problem.

## What changes are included in this PR?

- Replaced `alert()` error handling with inline error messages inside the video wrapper
- Handle `NotAllowedError` (permission denied), `NotFoundError` (no camera), and `NotSupportedError` (HTTPS required) with specific error messages and guidance
- Added a "Try again" button that re-calls camera setup without page reload
- Added a loading spinner shown while the COCO-SSD model downloads
- Fixed the hardcoded Windows path (`C:\Users\Konda Reddy\...`) in the Home button to a relative path (`../main.html`)
- Added missing viewport meta tag for mobile rendering

## Are these changes tested?

Yes. Tested locally by:
1. Denying camera permission — inline error message appears with retry button
2. Clicking retry after granting permission — detection starts correctly
3. Loading on slow connection — spinner visible during model download
4. Clicking Home button — navigates correctly to main.html

## Are there any user-facing changes?

Yes. Users now see:
- A loading spinner while the detection model downloads
- A clear error message when camera access fails
- A retry button to try again without reloading
- A working Home button (was broken due to hardcoded path)

## Screenshots (if applicable)

N/A — changes are best tested by denying camera permission in the browser.
