### PR TITLE
fix: About page heading text “Moovit” is not visible on dark background

### DIFF
--- a/about.html
+++ b/about.html
@@ -214,17 +214,15 @@
       font-size: 4rem;
       font-weight: 900;
       margin-bottom: 1.5rem;
-      color: var(--text-white);
+      color: white;
       letter-spacing: -1px;
       line-height: 1.1;
       text-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
     }
 
     .hero h1 span {
-      background: linear-gradient(135deg, var(--accent), #ffed4e);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      color: white;
+      -webkit-text-fill-color: white;
     }
 
     .hero p {


### PR DESCRIPTION
solve issue no. #234 