### PR TITLE
bug: Login and Sign-Up modals render simultaneously and overlap on page load

### DIFF
--- a/live-detection/live-detection.html
+++ b/live-detection/live-detection.html
@@ -16,7 +16,7 @@
 <body>
   <header>
     <h1>Live Object Detection 🔍</h1>
-    <a href="C:\\Users\\Konda Reddy\\OneDrive\\Desktop\\MooVit\\main.html" class="btn btn-light">← Home</a>
+    <a href="../main.html" class="btn btn-light">← Home</a>
   </header>
 
   <main>

--- a/sharp-detection/sharp-detection.html
+++ b/sharp-detection/sharp-detection.html
@@ -77,7 +77,7 @@
 <body>
   <header>
     <h1>Sharp Object Detection</h1>
-    <a href="C:\\Users\\Konda Reddy\\OneDrive\\Desktop\\MooVit\\main.html" class="btn btn-light">← Home</a>
+    <a href="../main.html" class="btn btn-light">← Home</a>
   </header>
 
   <main>

--- a/transport.css
+++ b/transport.css
@@ -846,12 +846,17 @@
       justify-content: center;
       align-items: center;
       pointer-events: none;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.3s ease, visibility 0.3s ease;
     }
 
     .login-modal.active,
     .signup-modal.active,
     .admin-modal.active {
       pointer-events: auto;
+      opacity: 1;
+      visibility: visible;
     }
 
     /* Error Messages */


### PR DESCRIPTION
Fixes the modal overlap issue caused by a mismatch between CSS selectors and HTML classes.

Fixes #424

- [x] I am contributing under GSSoC'26