### PR TITLE
feat: add dynamic column sorting to Routes Management table

### DIFF
--- a/Routes/route.html
+++ b/Routes/route.html
@@ -197,12 +197,13 @@
           <table class="table table-striped table-hover align-middle" id="routesTable">
             <thead class="table-dark">
               <tr>
-                <th><i class="bi bi-hash"></i> Route ID</th>
+                <th class="sortable user-select-none" data-sort="id" style="cursor:pointer" title="Sort by Route ID"><i class="bi bi-hash"></i> Route ID <i class="bi bi-arrow-down-up ms-1 text-muted sort-icon"></i></th>
                 <th><i class="bi bi-geo-alt"></i> Origin</th>
                 <th><i class="bi bi-pin-map"></i> Destination</th>
                 <th><i class="bi bi-activity"></i> Status</th>
-                <th><i class="bi bi-rulers"></i> Distance</th>
-                <th><i class="bi bi-clock"></i> Est. Time</th>
+                <th class="sortable user-select-none" data-sort="priority" style="cursor:pointer" title="Sort by Priority"><i class="bi bi-flag"></i> Priority <i class="bi bi-arrow-down-up ms-1 text-muted sort-icon"></i></th>
+                <th class="sortable user-select-none" data-sort="distance" style="cursor:pointer" title="Sort by Distance"><i class="bi bi-rulers"></i> Distance <i class="bi bi-arrow-down-up ms-1 text-muted sort-icon"></i></th>
+                <th class="sortable user-select-none" data-sort="estimatedTime" style="cursor:pointer" title="Sort by Est. Time"><i class="bi bi-clock"></i> Est. Time <i class="bi bi-arrow-down-up ms-1 text-muted sort-icon"></i></th>
                 <th><i class="bi bi-fuel-pump"></i> Fuel Cost</th>
                 <th><i class="bi bi-calendar"></i> Start Time</th>
                 <th><i class="bi bi-gear"></i> Actions</th>

--- a/Routes/route.js
+++ b/Routes/route.js
@@ -17,6 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
   
   let routes = [];
   let editIndex = -1;
+  // State object to track the current active sort column and direction
+  let currentSort = { field: null, direction: 'asc' };
   
   // Fuel price per km (can be adjusted)
   const FUEL_PRICE_PER_KM = 8.5; // ₹8.5 per km average
@@ -30,6 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupEventListeners();
     setupCharts();
     loadSampleData();
+    setupSorting();
     update();
   }
   
@@ -263,6 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     modal.hide();
+    if (currentSort.field) sortRoutes();
     renderRoutes();
     update();
   }
@@ -297,6 +301,11 @@ document.addEventListener('DOMContentLoaded', () => {
           <span class="badge bg-${statusColor} statusBadge">${route.status}</span>
         </td>
         <td>
+          <span class="badge bg-light text-dark priority-${route.priority.toLowerCase()}">
+            <i class="bi bi-flag-fill"></i> ${route.priority}
+          </span>
+        </td>
+        <td>
           <i class="bi bi-rulers"></i> ${route.distance} km
         </td>
         <td>
@@ -321,11 +330,6 @@ document.addEventListener('DOMContentLoaded', () => {
             <button class="btn btn-danger" onclick="deleteRoute(${index})">
               <i class="bi bi-trash"></i>
             </button>
-          </div>
-          <div class="mt-1">
-            <span class="badge bg-light text-dark priority-${route.priority.toLowerCase()}">
-              <i class="bi bi-flag-fill"></i> ${route.priority}
-            </span>
           </div>
         </td>
       `;
@@ -352,6 +356,74 @@ document.addEventListener('DOMContentLoaded', () => {
       'Critical': 'danger'
     };
     return colors[priority] || 'secondary';
+  }
+  
+  /**
+   * Initializes event listeners for all sortable table headers.
+   * Enables toggling sort direction on click and dynamically updates header icons.
+   */
+  function setupSorting() {
+    document.querySelectorAll('th.sortable').forEach(th => {
+      th.addEventListener('click', () => {
+        const field = th.dataset.sort;
+        
+        // Toggle sort direction if clicking the same column, otherwise default to ascending
+        if (currentSort.field === field) {
+          currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+        } else {
+          currentSort.field = field;
+          currentSort.direction = 'asc';
+        }
+        
+        // Reset all header icons to the default inactive state
+        document.querySelectorAll('th.sortable .sort-icon').forEach(icon => {
+          icon.className = 'bi bi-arrow-down-up ms-1 text-muted sort-icon';
+        });
+        
+        // Apply the active directional icon (up/down arrow) to the currently sorted column
+        const icon = th.querySelector('.sort-icon');
+        if (currentSort.direction === 'asc') {
+          icon.className = 'bi bi-arrow-up ms-1 sort-icon';
+        } else {
+          icon.className = 'bi bi-arrow-down ms-1 sort-icon';
+        }
+        
+        // Re-sort the underlying data array and re-render the table
+        sortRoutes();
+        renderRoutes();
+      });
+    });
+  }
+
+  /**
+   * Sorts the global `routes` array in place based on `currentSort` state.
+   * Handles numeric sorting, alphanumeric ID sorting, and custom Priority mapping.
+   */
+  function sortRoutes() {
+    if (!currentSort.field) return;
+
+    // Define a severity mapping so that priority can be sorted logically instead of alphabetically
+    const priorityOrder = { 'Low': 1, 'Medium': 2, 'High': 3, 'Critical': 4 };
+
+    routes.sort((a, b) => {
+      let valA = a[currentSort.field];
+      let valB = b[currentSort.field];
+
+      // Normalize specific fields to ensure accurate comparison
+      if (currentSort.field === 'priority') {
+        valA = priorityOrder[valA] || 0;
+        valB = priorityOrder[valB] || 0;
+      } else if (currentSort.field === 'id') {
+        // Case-insensitive alphanumeric sort for string IDs
+        valA = valA.toString().toLowerCase();
+        valB = valB.toString().toLowerCase();
+      }
+      
+      // Perform the comparison taking into account the chosen sort direction
+      if (valA < valB) return currentSort.direction === 'asc' ? -1 : 1;
+      if (valA > valB) return currentSort.direction === 'asc' ? 1 : -1;
+      return 0; // Return 0 to maintain stable sorting relative order
+    });
   }
   
   function update() {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #431.

## Rationale for this change

As the number of active routes grows, finding specific routes or analyzing operational metrics in a statically rendered table becomes inefficient. This change introduces dynamic table sorting to improve data organization, allowing users to quickly prioritize urgent routes, organize by estimated delivery time, and find routes using alphanumeric IDs.

## What changes are included in this PR?

- Extracted the **Priority** metric into its own dedicated table column to make it explicitly sortable.
- Added data attributes and interactive sorting arrows (`bi-arrow-down-up`) to the table headers in `route.html` for **Route ID**, **Priority**, **Distance**, and **Est. Time**.
- Implemented a custom sorting logic (`sortRoutes`) and state tracker (`currentSort`) in `route.js` that handles:
  - Case-insensitive alphanumeric sorting for Route IDs.
  - Custom severity-indexed sorting for Priorities (`Low` < `Medium` < `High` < `Critical`).
  - Standard numeric sorting for Distance and Estimated Time.
- Added JSDoc and inline comments explaining the sorting implementation logic.

## Are these changes tested?

Yes. I tested the changes locally in the browser to verify that:
1. Clicking headers correctly toggles between ascending and descending order.
2. The UI arrows update dynamically based on the active column and sort direction.
3. The sorting is stable and does not cause unexpected layout shifts.
4. Added or edited routes instantly conform to the currently active sort state.

## Are there any user-facing changes?

Yes, the Routes Management table headers for Route ID, Priority, Distance, and Est. Time are now clickable. Visual directional arrows appear to indicate the active sorting state.

## Screenshots 
<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 50 26 PM" src="https://github.com/user-attachments/assets/3406b7af-b58a-4590-aa48-e2de36416431" />
<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 50 33 PM" src="https://github.com/user-attachments/assets/9eba5fe3-e44d-434a-93fe-6046ebeee44b" />
<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 50 37 PM" src="https://github.com/user-attachments/assets/3125aeab-03cc-4d4a-93b4-d404338cffb3" />


<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 51 36 PM" src="https://github.com/user-attachments/assets/afa94da8-fca0-4cc8-bef5-21af410b4ec7" />
<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 51 40 PM" src="https://github.com/user-attachments/assets/cc3404c3-f5f4-4e14-b4b2-04b72431c918" />
<img width="1710" height="1107" alt="Screenshot 2026-05-17 at 12 51 48 PM" src="https://github.com/user-attachments/assets/e17285af-fa31-476b-8efe-ba74ba0f47b5" />
