### PR TITLE
fix: resolve welcome header and subheader text contrast in light mode

### DIFF
--- a/main.html
+++ b/main.html
@@ -59,6 +59,12 @@
             color: var(--gray-800);
         }
 
+        html.theme-light .welcome-section h2,
+        html.theme-light .welcome-section p {
+            color: var(--gray-800);
+            text-shadow: none;
+        }
+
         /* Header */
          header {
         background: rgba(255, 255, 255, 0.4); 


### PR DESCRIPTION
### Description
Fixed a typography visibility issue where the main dashboard header ("Welcome to MooVit") and its subheader text remained white when the theme was toggled to light mode, making them completely unreadable against the light background.

### Changes Implemented
- Added CSS rules scoped to `html.theme-light` targeting `.welcome-section h2` and `.welcome-section p`.
- Updated text color to `var(--gray-800)` for high-contrast accessibility compliance.
- Removed the overlapping white text-shadow on light mode for clean readability.

### Verification
Verified locally; the text layers now dynamically scale contrast perfectly between light and dark backgrounds.