### PR TITLE
fix: make social links visible and properly aligned in Road Safety footer

### DIFF
--- a/Safety and awareness/styles.css
+++ b/Safety and awareness/styles.css
@@ -540,6 +540,8 @@ footer {
 .social-links {
     display: flex;
     gap: 15px;
+    align-items: center;
+    margin-top: 10px;
 }
 
 .social-links a {
@@ -553,11 +555,26 @@ footer {
     color: white;
     font-size: 1.2em;
     transition: all 0.3s ease;
+    text-decoration: none;
+    flex-shrink: 0;
+}
+
+.social-links a i {
+    font-size: 1rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    color: white;
+    pointer-events: none;
 }
 
 .social-links a:hover {
     transform: translateY(-3px);
     background: var(--accent-blue);
+    box-shadow: 0 5px 15px rgba(0, 102, 204, 0.4);
 }
 
 .footer-bottom {


### PR DESCRIPTION
## What does this PR do?
Fixes invisible and misaligned social media icons in the footer of the Road Safety & Awareness page.

## Problem
Social link buttons were completely blank/invisible. 
Icons only appeared faintly on hover and were misaligned.

## Changes made
- Added proper styling for `.social-links a i` so icons are always visible
- Added `text-decoration: none` and `flex-shrink: 0` to anchor tags
- Added `align-items: center` and `margin-top` to `.social-links`
- Added hover box-shadow for better visual feedback

Closes #396