### PR TITLE
Corrected Clone repo commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MooVit/
 │   │   └── safety.py
 │   ├── models/                    # ML / Detection models
 │   │   └── detection_model.py
-│   ├── utils/                     # Helper functio
+│   ├── utils/                     # Helper function
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ MooVit/
 1. Clone the repo:
 
 ```bash
-git clone https://github.com/ShubhangiRoy12/moovit.git
-cd moovit
+git clone https://github.com/ShubhangiRoy12/MooVit.git
+cd MooVit
 ```
 
 2. Install backend dependencies:


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #304 

## Rationale for this change

The clone repository command mentioned in the README.md file was incorrect, which could cause confusion or setup issues for contributors while cloning the project locally.

## What changes are included in this PR?

* Corrected the clone repository command in README.md
* Improved setup accuracy for contributors

## Are these changes tested?

Yes.
The updated clone command was tested successfully by cloning the repository locally.


## Screenshots
### Before
<img width="870" height="205" alt="image" src="https://github.com/user-attachments/assets/13f26c26-b4a2-4131-9990-0fe1cce32cd1" />

### After
<img width="840" height="169" alt="image" src="https://github.com/user-attachments/assets/26d1b8c8-5293-453c-9001-2ddca0d30857" />
