### PR TITLE
Fix: Resolved overlapping Login and Signup modal issue

### DIFF
--- a/transport.css
+++ b/transport.css
@@ -842,15 +842,18 @@
       left: 0;
       width: 100%;
       height: 100%;
-      display: flex;
+
+      display: none;   /* FIXED */
       justify-content: center;
       align-items: center;
+
       pointer-events: none;
     }
 
     .login-modal.active,
     .signup-modal.active,
     .admin-modal.active {
+      display: flex;      /* FIXED */
       pointer-events: auto;
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change
The Login and Signup authentication modals were overlapping because inactive modals were still rendered with display: flex. This caused multiple modal containers to remain visible simultaneously, affecting UI clarity and user experience.

## What changes are included in this PR?
Updated modal visibility handling in transport.css
Changed inactive modals from display: flex to display: none
Enabled display: flex only for active modals
Improved modal interaction behavior and prevented overlapping UI elements

## Are these changes tested?
Yes.

Tested the following scenarios:

Login modal opens correctly
Signup modal opens correctly
Switching between modals works properly
No overlapping occurs after opening or closing modals
Verified responsive behavior on smaller screens

BEFORE: 
<img width="1562" height="866" alt="image" src="https://github.com/user-attachments/assets/e4a7b441-715e-4dcc-932a-8d8a60fd782f" />
AFTER: 
<img width="1702" height="892" alt="image" src="https://github.com/user-attachments/assets/af05b285-8fd8-4064-90b3-6813add25fef" />
