### PR TITLE
fix: improve hero section text visibility in light mode

### DIFF
--- a/main.html
+++ b/main.html
@@ -58,6 +58,17 @@
             background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
             color: var(--gray-800);
         }
+        
+        /* Fix hero text visibility in light mode */
+        html.theme-light .welcome-section h2 {
+            color: #0f172a;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+        }
+
+        html.theme-light .welcome-section p {
+            color: #1e293b;
+            opacity: 1;
+        }
 
         /* Header */
          header {


### PR DESCRIPTION
## What does this PR do?
Fixes hero section text becoming invisible in light mode.

## Problem
The welcome section text is hardcoded as white, making it unreadable when light mode is active.

## Fix
Added light mode specific CSS overrides for .welcome-section h2 and p to ensure readable dark text in light mode.

Closes #353