### PR TITLE
Fix: Remove dead "Careers" link from footer navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,6 @@
           <li><a href="about.html">About Us</a></li>
           <li><a href="services.html">Services</a></li>
           <li><a href="contact.html">Contact</a></li>
-          <li><a href="careers.html">Careers</a></li>
           <li><a href="feedback.html">Feedback</a></li>
         </ul>
       </div>


### PR DESCRIPTION
# Fix: Remove dead "Careers" link from footer navigation

Closes Issue: #233 

---

## Description of Changes

This PR removes the non-functional **"Careers"** link from the footer's **Quick Links** section.

Since MooVit is currently a student project and does not have an active recruitment page, the `careers.html` link resulted in a broken navigation path and could confuse users.

To resolve this issue, the corresponding `<li>` element was completely removed from `index.html`, improving footer clarity and user experience.

---

## Changes Made

### File Modified
- `index.html`

### Action Performed
- Removed the following line from the footer navigation:

```html
<li><a href="careers.html">Careers</a></li>
```

---

## Screenshots

### Before
<img width="1904" height="1123" alt="Screenshot 2026-05-19 222742" src="https://github.com/user-attachments/assets/62a0b200-b2b6-4820-a96a-b69d70f73441" />


- The **"Careers"** link is visible under the **"Contact"** link.

### After
<img width="1912" height="1118" alt="Screenshot 2026-05-19 222804" src="https://github.com/user-attachments/assets/d468ccad-548b-475e-9c0a-13bb5a90c059" />


- The **"Careers"** link has been successfully removed, leaving only functional navigation links.

---

## Testing Checklist

- [x] Verified the "Careers" link is completely removed from the footer.
- [x] Ensured the layout of the remaining Quick Links is not broken.
- [x] Tested remaining footer links to confirm navigation remains functional.
- [x] Checked responsiveness on mobile view to ensure footer alignment remains intact.