### PR TITLE
fix: restore cursor visibility on Login and Signup form elements

### DIFF
--- a/login.html
+++ b/login.html
@@ -157,6 +157,37 @@
   margin-right: 6px;
   width: auto !important;
 }
+/* Fix: Restore cursor visibility on form elements
+   The global cursor.js hides the system cursor site-wide.
+   These overrides ensure proper pointer interactions on auth pages. */
+body {
+  cursor: auto;
+}
+
+.auth-container input,
+.auth-container input[type="checkbox"] {
+  cursor: text;
+  position: relative;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.auth-container input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.auth-container button {
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.auth-container a {
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+}
   </style>
 </head>
 

--- a/register.html
+++ b/register.html
@@ -124,6 +124,37 @@
     .auth-container a:hover {
       text-decoration: underline;
     }
+    /* Fix: Restore cursor visibility on form elements
+   The global cursor.js hides the system cursor site-wide.
+   These overrides ensure proper pointer interactions on auth pages. */
+body {
+  cursor: auto;
+}
+
+.auth-container input,
+.auth-container input[type="checkbox"] {
+  cursor: text;
+  position: relative;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.auth-container input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.auth-container button {
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.auth-container a {
+  cursor: pointer;
+  position: relative;
+  z-index: 10;
+}
   </style>
 </head>
 


### PR DESCRIPTION
Fixes #562

## Problem
The global cursor.js hides the system cursor (cursor: none on body).
The login.html and register.html pages had no overrides, causing the
cursor to disappear over form inputs and buttons.

## Fix
Added CSS overrides to .auth-container elements on both pages:
- `cursor: text` on text/password inputs
- `cursor: pointer` on buttons, checkboxes, and links  
- `z-index: 10` and `pointer-events: auto` to prevent overlay blocking

## Files Changed
- login.html
- register.html

## Tested
Verified cursor is visible and correctly styled on all form elements
on both Login and Signup pages.