### PR TITLE
Fix non-functional contact page actions

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -734,22 +734,28 @@
                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8a15.1 15.1 0 0 0 6.6 6.6l2.1-2.1a1 1 0 0 1 1-.2c1.1.4 2.3.6 3.5.6a1 1 0 0 1 1 1V20a1 1 0 0 1-1 1C10.1 21 3 13.9 3 4a1 1 0 0 1 1-1h2.5a1 1 0 0 1 1 1c0 1.2.2 2.4.6 3.5a1 1 0 0 1-.2 1l-2.3 2.3z"/></svg>
               </div>
               <div class="info-card-content">
-                <h4>Call Us</h4>
-                <p>+91 98765 XXXXX</p>
-                <p>24/7 Customer Support</p>
+                 <h4>Call Us</h4>
+                 <a href="tel:+9198765XXXXX">
+                    +91 98765 XXXXX
+                 </a>
+                 <p>24/7 Customer Support</p>
               </div>
             </div>
 
             <div class="info-card">
               <div class="icon">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M2 6v12h20V6l-10 7L2 6z"/></svg>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M2 6v12h20V6l-10 7L2 6z"/>
+                </svg>
               </div>
               <div class="info-card-content">
-                <h4>Email Us</h4>
-                <p>shubhangi.23bai11165@vitbhopal.ac.in</p>
-                <p>Quick Response Guaranteed</p>
+                 <h4>Email Us</h4>
+                 <a href="mailto:shubhangi.23bai11165@vitbhopal.ac.in">
+                  shubhangi.23bai11165@vitbhopal.ac.in
+                 </a>
+                 <p>Quick Response Guaranteed</p>
+                </div>
               </div>
-            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #627

## Rationale for this change
The “Call Us” and “Email Us” sections on the Contact page looked clickable, but no action was triggered when users clicked on them. This made the contact section feel incomplete and confusing from a user experience perspective.

## What changes are included in this PR?
- Added a `mailto:` link to the email section
- Added a `tel:` link to the phone section
- Made both contact options properly interactive

## Are these changes tested?
Yes, tested locally.

- Clicking the email now opens the default mail application
- Clicking the phone number now triggers the calling handler/protocol

## Are there any user-facing changes?
Yes. Users can now directly interact with the contact information from the Contact page.

