### PR TITLE
fix: style Premium Access modal close button and align with design la…

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
   <div class="overlay" id="overlay" onclick="closeAllModals()"></div>
 
   <div class="service-alert" id="serviceAlert">
+    <button class="close-btn" onclick="closeAllModals()">&times;</button>
     <h3>🔒 Premium Access</h3>
     <p>Please login to access detailed service information and pricing.</p>
     <div class="alert-buttons">

--- a/transport.css
+++ b/transport.css
@@ -989,6 +989,66 @@ a, button, input, .card {
   text-align: center;
 }
 
+.alert-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 1.75rem;
+}
+
+.alert-btn {
+  padding: 12px 24px;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.alert-btn.primary {
+  background: var(--button-primary);
+  color: white;
+}
+
+.alert-btn.primary:hover {
+  background: var(--button-primary-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px var(--button-shadow);
+}
+
+.alert-btn.close {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--text-primary);
+  border: 1px solid var(--panel-border);
+}
+
+body[data-theme="dark"] .alert-btn.close {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.alert-btn.close:hover {
+  background: rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+body[data-theme="dark"] .alert-btn.close:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+@media (max-width: 480px) {
+  .alert-buttons {
+    flex-direction: column;
+  }
+  .alert-btn {
+    width: 100%;
+  }
+}
+
 /* Mobile Responsive */
 @media (max-width: 768px) {
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #635 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The "Close" button inside the Premium Access modal was rendering as a plain, unstyled OS-native element. This stood out as visually inconsistent with the custom UI elements used across the rest of the application. Applying the site's theme buttons and adding a standard dismissal `×` icon brings visual parity and enhances the UX.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Added standard top-right dismissal button (`.close-btn` with `&times;` icon) inside the Premium Access (`#serviceAlert`) modal in `index.html`.
- Added custom styling for `.alert-buttons` and `.alert-btn` in `transport.css` to format:
  - **Login Now** as a primary CTA button utilizing theme variables (`var(--button-primary)`, `var(--button-primary-hover)`).
  - **Close** as a subtle, theme-aware secondary button.
- Implemented full responsiveness for buttons to stack on smaller screens (below `480px`).
- Integrated light/dark mode variables so that button colors dynamically update.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, verified manually by serving the static pages locally and checking styling, responsive behavior, and theme transitions (light/dark theme toggles).

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, users will now see a polished Premium Access modal with a styled primary CTA, a matching secondary Close button, and a top-right `×` dismissal icon, instead of unstyled links and default browser buttons.

## Screenshots (if applicable)
<!--
Add screenshots if there are any user facing changes 
<img width="970" height="362" alt="image" src="https://github.com/user-attachments/assets/cf678da6-54eb-4227-897c-e97b092ec853" />

-->
*(The redesign adds the same standard close cross and button styling seen in other dashboard modals.)*
