### PR TITLE
Fix missing social media links in Road Safety and Awareness page footer

### DIFF
--- a/Safety and awareness/index.html
+++ b/Safety and awareness/index.html
@@ -216,9 +216,9 @@
             <div class="footer-section">
                 <h4>Follow Us</h4>
                 <div class="social-links">
-                    <a href="#"><i class="fab fa-facebook"></i></a>
-                    <a href="#"><i class="fab fa-twitter"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a href="https://www.bing.com/ck/a?!&&p=9cc17a5751163b6ee8c1c443e165d3b32e8ded91b3e5f1de4d3382ea51e09f8eJmltdHM9MTc3OTU4MDgwMA&ptn=3&ver=2&hsh=4&fclid=3a3a1a67-27af-6bae-2d7b-0cf3263c6ad5&psq=facebook&u=a1aHR0cHM6Ly93d3cuZmFjZWJvb2suY29tLw"><i class="fab fa-facebook"></i></a>
+                    <a href="https://www.bing.com/ck/a?!&&p=9cc17a5751163b6ee8c1c443e165d3b32e8ded91b3e5f1de4d3382ea51e09f8eJmltdHM9MTc3OTU4MDgwMA&ptn=3&ver=2&hsh=4&fclid=3a3a1a67-27af-6bae-2d7b-0cf3263c6ad5&psq=twitter&u=a1aHR0cHM6Ly93d3cudHdpdHRlci5jb20v"><i class="fab fa-twitter"></i></a>
+                    <a href="https://www.bing.com/ck/a?!&&p=9cc17a5751163b6ee8c1c443e165d3b32e8ded91b3e5f1de4d3382ea51e09f8eJmltdHM9MTc3OTU4MDgwMA&ptn=3&ver=2&hsh=4&fclid=3a3a1a67-27af-6bae-2d7b-0cf3263c6ad5&psq=instagram&u=a1aHR0cHM6Ly93d3cuaW5zdGFncmFtLmNvbS8="><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #648

## Rationale for this change

The social media icons on the Road Safety and Awareness page footer were using placeholder (`#`) links and were not redirecting users to the intended social media platforms. This affected user navigation and functionality.

## What changes are included in this PR?

* Replaced placeholder (`#`) links with valid social media URLs.
* Fixed the functionality of social media icons in the footer section.
* Ensured proper redirection when users click on the icons.

## Are these changes tested?

Yes, the changes were tested manually by clicking each social media icon and verifying that they redirect correctly.

## Are there any user-facing changes?

Yes. Users can now navigate correctly through the social media links from the footer section.

## Screenshots (if applicable)

Add screenshots if available.
