### PR TITLE
Fix: navbar tracking link

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -223,7 +223,7 @@
         <ul class="nav-links">
           <li><a href="index.html" class="nav-link active">Home</a></li>
           <li><a href="services.html" class="nav-link">Services</a></li>
-          <li><a href="#" class="nav-link">Tracking</a></li>
+          <li><a href="tracking-dashboard.html" class="nav-link">Tracking</a></li>
           <li><a href="about.html" class="nav-link">About</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
         <ul class="nav-links">
           <li><a href="index.html" class="nav-link active">Home</a></li>
           <li><a href="services.html" class="nav-link">Services</a></li>
-          <li><a href="#" class="nav-link">Tracking</a></li>
-          <li><a href="#about" class="nav-link">About</a></li>
+          <li><a href="tracking-dashboard.html" class="nav-link">Tracking</a></li>
+          <li><a href="about.html" class="nav-link">About</a></li>
           <li><a href="contact.html" class="nav-link">Contact</a></li>
         </ul>
       </nav>
@@ -76,7 +76,7 @@
       </div>
     </div>
     <div class="mobile-menu" id="mobileMenu">
-      <a href="index.html">Home</a><a href="services.html">Services</a><a href="#">Tracking</a><a
+      <a href="index.html">Home</a><a href="services.html">Services</a><a href="tracking-dashboard.html">Tracking</a><a
         href="contact.html">Contact</a>
       <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">
         <span class="theme-toggle-icon" aria-hidden="true">🌙</span>


### PR DESCRIPTION
Which issue does this PR close?
Closes #247.

Rationale for this change
The tracking link in the navbar was not working because it was pointing to a placeholder (#). This change fixes the navigation by linking it to the tracking-dashboard.html page so users can access the shipment tracking dashboard directly.
What changes are included in this PR?
Updated navbar tracking link to point to tracking-dashboard.html
Ensured tracking dashboard page is accessible from main navigation
Verified routing works correctly using Live Server

Are these changes tested?
Yes.
The changes were tested locally using Live Server. The tracking link correctly opens the tracking-dashboard.html page and the dashboard loads without errors.

Are there any user-facing changes?
Yes.
Users can now click the Tracking link in the navbar and directly access the tracking dashboard page.

Screenshots 
<img width="1879" height="1041" alt="mooti1" src="https://github.com/user-attachments/assets/3c6c1fdf-53a0-4778-acc3-8e6aefa93d27" />
<img width="1852" height="1986" alt="mooti 2" src="https://github.com/user-attachments/assets/069f3903-ac55-4cdb-8110-6ef676c4e88a" />

