### PR TITLE
fix: replace emojis with high-performance SVG icons in feedback page

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -237,7 +237,7 @@
             </svg></button>
         </div>
         <button class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">
-          <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+          <span class="theme-toggle-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-svg-moon" style="width:18px; height:18px; display:inline-block; vertical-align:middle;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></span>
           <span class="theme-toggle-label">Dark Mode</span>
         </button>
         <div class="auth-divider"></div>
@@ -251,7 +251,7 @@
       <a href="index.html">Home</a><a href="services.html">Services</a><a href="#">Tracking</a><a
         href="contact.html">Contact</a>
       <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false">
-        <span class="theme-toggle-icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-svg-moon" style="width:18px; height:18px; display:inline-block; vertical-align:middle;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></span>
         <span class="theme-toggle-label">Dark Mode</span>
       </button>
       <div class="mobile-auth"><a href="#" onclick="openLoginPopup()">Login</a><a href="#"
@@ -273,7 +273,7 @@
 
 <div class="popup" id="thankPopup">
   <div class="popup-content">
-    <h3>🎉 Thank You!</h3>
+    <h3><svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-svg" style="display:inline-block; vertical-align:middle; margin-right:6px;"><circle cx="12" cy="12" r="10"></circle><path d="M8 14s1.5 2 4 2 4-2 4-2"></path><line x1="9" y1="9" x2="9.01" y2="9"></line><line x1="15" y1="9" x2="15.01" y2="9"></line></svg>Thank You!</h3>
     <p>Your feedback has been successfully submitted.</p>
     <button onclick="closePopup()" style="margin-top:1rem;padding:0.6rem 1.5rem;border-radius:20px;border:none;background:#2563eb;color:white;">Close</button>
   </div>
@@ -370,7 +370,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 Transport Co. | All Rights Reserved. | Designed with ❤️ for Excellence</p>
+      <p>&copy; 2025 Transport Co. | All Rights Reserved. | Designed with <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="red" stroke-linecap="round" stroke-linejoin="round" class="icon-svg-heart" style="display:inline-block; vertical-align:middle; width:16px; height:16px;"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg> for Excellence</p>
     </div>
   </footer>
 <script>
@@ -383,15 +383,19 @@
     body.setAttribute("data-theme", theme);
     localStorage.setItem("moovit-theme", theme);
 
-    themeButtons.forEach((button) => {
-      const icon = button.querySelector(".theme-toggle-icon");
-      const label = button.querySelector(".theme-toggle-label");
-      const darkMode = theme === "dark";
+      themeButtons.forEach((button) => {
+        const icon = button.querySelector(".theme-toggle-icon");
+        const label = button.querySelector(".theme-toggle-label");
+        const darkMode = theme === "dark";
 
-      button.setAttribute("aria-pressed", String(darkMode));
-      if (icon) icon.textContent = darkMode ? "☀️" : "🌙";
-      if (label) label.textContent = darkMode ? "Light Mode" : "Dark Mode";
-    });
+        button.setAttribute("aria-pressed", String(darkMode));
+        if (icon) {
+          icon.innerHTML = darkMode 
+            ? `<svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-svg-sun" style="width:18px; height:18px; display:inline-block; vertical-align:middle;"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>` 
+            : `<svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" class="icon-svg-moon" style="width:18px; height:18px; display:inline-block; vertical-align:middle;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>`;
+        }
+        if (label) label.textContent = darkMode ? "Light Mode" : "Dark Mode";
+      });
   }
 
   applyTheme(root.getAttribute("data-theme") || "light");


### PR DESCRIPTION
Closed #695 

### Summary
Swaps the emoji characters in the popup modals, footer labels, and active theme toggler on the Feedback page with customized SVGs.

### Changes Made
- Modified [feedback.html](file:///c:/Users/Debasmita/Desktop/MooVit/MooVit/feedback.html) to substitute emojis with SVG layouts.
- Aligned scripting states to dynamically swap SVG graphics.
