### PR TITLE
fix: add dark mode styles for form labels in car ride sharing section

### DIFF
--- a/sharingcab/sharingcab.html
+++ b/sharingcab/sharingcab.html
@@ -47,6 +47,10 @@
       background: linear-gradient(135deg, #2d3748 0%, #1a202c 100%) !important;
     }
 
+    .dark-mode .form-label {
+      color: #e2e8f0 !important;
+    }
+
     header {
       background: rgba(255, 255, 255, 0.1);
       backdrop-filter: blur(10px);


### PR DESCRIPTION
## Which issue does this PR close?
Closes #674

## Rationale for this change

The form labels (From, To, Passengers, Date, Time, Vehicle Type) were hard to read in dark mode. This PR adds the missing CSS.

## What changes are included in this PR?

Added `.dark-mode .form-label` CSS rule to `sharingcab/sharingcab.html`

## Are these changes tested?

Yes, tested locally in browser.

## Are there any user-facing changes?

Yes - labels are now readable in dark mode.


## Screenshots
Before: 
<img width="1919" height="653" alt="image" src="https://github.com/user-attachments/assets/2dd0ad5f-f351-4a15-b152-506b87d63c5d" />
After: 
<img width="1919" height="625" alt="image" src="https://github.com/user-attachments/assets/bca39fd3-81c0-4f63-92ee-9c6edb468b62" />
