### PR TITLE
fix: standardize legacy branding references to MooVit

### DIFF
--- a/Routes/route.html
+++ b/Routes/route.html
@@ -223,7 +223,7 @@
 
   <footer class="bg-light py-3 mt-5">
     <div class="container text-center">
-      <small class="text-muted">&copy; 2025 Transport Co. | Enhanced Route Management System</small>
+      <small class="text-muted">&copy; 2025 MooVit | Enhanced Route Management System</small>
     </div>
   </footer>
 

--- a/Schedule/schedule.html
+++ b/Schedule/schedule.html
@@ -156,9 +156,9 @@
       </iframe>
     </section>
 
-  </main>
+  </main> 
 
-  <footer class="bg-light text-center py-2 mt-4" role="contentinfo">&copy; 2025 Transport Co.</footer>
+  <footer class="bg-light text-center py-2 mt-4" role="contentinfo">&copy; 2025 MooVit</footer>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>

--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.png">
-  <title>About Us - Moovit</title>
+  <title>About Us - MooVit</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
     
@@ -665,14 +665,14 @@
     <a href="./main.html" class="back-btn">
       ⬅ Back
     </a>
-    <a href="./main.html" class="logo">Moovit</a>
+    <a href="./main.html" class="logo">MooVit</a>
     <button id="theme-toggle" class="theme-toggle" title="Toggle theme">🌙</button>
   </header>
 
   <!-- Hero Section -->
   <section class="hero">
     <div class="hero-content">
-      <h1>About <span>Moovit</span></h1>
+      <h1>About <span>MooVit</span></h1>
       <p>Your trusted partner for seamless, reliable, and efficient logistics solutions across the nation.</p>
     </div>
   </section>
@@ -684,7 +684,7 @@
       <p class="section-subtitle">Redefining logistics with innovation, reliability, and customer-first values</p>
       <div class="mission-card">
         <p>
-          At <strong>Moovit </strong>, our mission is to revolutionize the logistics industry by providing 
+          At <strong>MooVit </strong>, our mission is to revolutionize the logistics industry by providing 
           stress-free, affordable, and efficient transportation solutions. We are committed to delivering 
           safe, reliable, and customer-focused services for both individuals and businesses. Every shipment 
           matters to us, and we treat your cargo as if it were our own.
@@ -739,7 +739,7 @@
         <div class="feature-card">
           <div class="feature-icon">🌍</div>
           <h3>Nationwide Reach</h3>
-          <p>Wherever you need to go, Moovit has the network to support your logistics journey.</p>
+          <p>Wherever you need to go, MooVit has the network to support your logistics journey.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon">📱</div>
@@ -781,7 +781,7 @@
     <!-- CTA Section -->
     <section class="cta-section animate-on-scroll">
       <h2>Ready to Experience the Difference?</h2>
-      <p>Join thousands of satisfied customers who trust Moovit for their logistics needs.</p>
+      <p>Join thousands of satisfied customers who trust MooVit for their logistics needs.</p>
       <div class="cta-buttons">
         <a href="./contact.html" class="btn btn-primary">Contact Us Today</a>
         <a href="./services.html" class="btn btn-secondary">Explore Services</a>
@@ -791,7 +791,7 @@
 
   <!-- Footer -->
   <footer>
-    <p>© 2025 Moovit. All Rights Reserved.</p>
+    <p>© 2025 MooVit. All Rights Reserved.</p>
   </footer>
 
   <script>

--- a/admin.html
+++ b/admin.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <link rel="icon" href="favicon.png">
-  <title>Admin Portal - Transport Co.</title>
+  <title>Admin Portal - MooVit</title>
   <style>
     /* Admin styles */
     body {
@@ -338,7 +338,7 @@
     <div class="admin-header">
       <div class="admin-badge">Admin Access</div>
       <h2>Control Panel</h2>
-      <div class="admin-subtitle">Transport Management System</div>
+      <div class="admin-subtitle">MooVit Management System</div>
     </div>
 
     <form id="admin-login-form">

--- a/careers.html
+++ b/careers.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.png">
-  <title>Careers - MoveIt</title>
+  <title>Careers - MooVit</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
     
@@ -660,13 +660,13 @@
     <a href="./main.html" class="back-btn">
       ⬅ Back
     </a>
-    <div class="logo">MoveIt</div>
+    <div class="logo">MooVit</div>
   </header>
 
   <!-- Hero Section -->
   <section class="hero">
     <div class="hero-content">
-      <h1>Join the <span>MoveIt</span> Team</h1>
+      <h1>Join the <span>MooVit</span> Team</h1>
       <p>Be part of a company that's transforming the logistics industry with innovation and passion.</p>
     </div>
   </section>
@@ -676,13 +676,13 @@
     <div class="status-banner">
       <span class="icon">💼</span>
       <h2>We're Not Currently Hiring</h2>
-      <p>Thank you for your interest in joining MoveIt! While we don't have any open positions at the moment, we're always looking to connect with talented individuals. Sign up below to be notified when new opportunities become available.</p>
+      <p>Thank you for your interest in joining MooVit! While we don't have any open positions at the moment, we're always looking to connect with talented individuals. Sign up below to be notified when new opportunities become available.</p>
     </div>
 
-    <!-- Why Join MoveIt Section -->
+    <!-- Why Join MooVit Section -->
     <section class="section">
-      <h2 class="section-title">Why Join MoveIt?</h2>
-      <p class="section-subtitle">Discover what makes MoveIt a great place to build your career</p>
+      <h2 class="section-title">Why Join MooVit?</h2>
+      <p class="section-subtitle">Discover what makes MooVit a great place to build your career</p>
       <div class="benefits-grid">
         <div class="benefit-card">
           <div class="benefit-icon">🚀</div>
@@ -800,7 +800,7 @@
 
   <!-- Footer -->
   <footer>
-    <p>© 2025 MoveIt. All Rights Reserved.</p>
+    <p>© 2025 MooVit. All Rights Reserved.</p>
   </footer>
 
   <script>

--- a/contact.html
+++ b/contact.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.png">
-  <title>Contact Us - Transport Co.</title>
+  <title>Contact Us - MooVit</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
     
@@ -647,7 +647,7 @@
     <button class="back-btn" onclick="smartGoBack()">
       ⬅ Back
     </button>
-    <div class="logo">Transport Co.</div>
+    <div class="logo">MooVit</div>
   </header>
 
   <div class="container">
@@ -746,7 +746,7 @@
               </div>
               <div class="info-card-content">
                 <h4>Email Us</h4>
-                <p>shubhangi.23bai11165@vitbhopal.ac.in</p>
+                <p>support@moovit.ai</p>
                 <p>Quick Response Guaranteed</p>
               </div>
             </div>

--- a/cookie.html
+++ b/cookie.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="favicon.png" />
-  <title>Cookie Policy | MoveIt</title>
+  <title>Cookie Policy | MooVit</title>
   <!-- COPY SAME STYLE BLOCK FROM privacy.html -->
       <style>
       /* Global Styles */
@@ -167,20 +167,20 @@
   <div class="back-btn">
     <a href="index.html">&#8592; Back</a>
   </div>
-  <div class="logo">MoveIt</div>
+  <div class="logo">MooVit</div>
 </nav>
 
 <section class="hero">
   <div class="hero-content">
     <h1>Cookie Policy</h1>
-    <p>Understanding how MoveIt uses cookies.</p>
+    <p>Understanding how MooVit uses cookies.</p>
   </div>
 </section>
 
 <section class="privacy">
   <h2>Our Use of Cookies</h2>
   <p>
-    MoveIt uses cookies and similar technologies to enhance website performance
+    MooVit uses cookies and similar technologies to enhance website performance
     and improve user experience.
   </p>
 
@@ -230,7 +230,7 @@
 
 
 <footer>
-  <p>© 2025 MoveIt. All Rights Reserved.</p>
+  <p>© 2025 MooVit. All Rights Reserved.</p>
 </footer>
 
 </body>

--- a/feedback.html
+++ b/feedback.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="../favicon.png">
-  <title>Feedback - Transport Co.</title>
+  <title>Feedback - MooVit</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="transport.css">
   <script>
@@ -217,7 +217,7 @@
             <circle cx="5.5" cy="18.5" r="2.5"></circle>
             <circle cx="18.5" cy="18.5" r="2.5"></circle>
           </svg></span>
-        <span class="logo-text">Transport<span class="highlight">Co.</span></span>
+        <span class="logo-text">Moo<span class="highlight">Vit</span></span>
       </a>
       <nav class="desktop-nav">
         <ul class="nav-links">
@@ -284,9 +284,8 @@
 <footer >
     <div class="footer-container">
       <div class="footer-about">
-        <h3>Transport Co.</h3>
-        <p>Your trusted logistics partner — ensuring safe, fast, and reliable delivery every time with innovative
-          solutions and unmatched customer service excellence across the globe.</p>
+        <h3>MooVit</h3>
+        <p>Your trusted safety and mobility partner — ensuring safe, accessible, and reliable navigation solutions through AI-powered real-time assistance.</p>
       </div>
 
       <div class="footer-links">
@@ -370,7 +369,7 @@
       </div>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 Transport Co. | All Rights Reserved. | Designed with ❤️ for Excellence</p>
+      <p>&copy; 2025 MooVit | All Rights Reserved. | Designed with ❤️ for Excellence</p>
     </div>
   </footer>
 <script>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Transport Co. offers seamless and reliable global shipping solutions.">
+  <meta name="description" content="MooVit offers seamless and reliable global shipping solutions.">
   <meta name="keywords" content="Transport, Shipping, Logistics, Cargo, Delivery, Freight">
   <link rel="icon" href="../favicon.png">
-  <title>Transport Co. - Your Cargo, Our Priority</title>
+  <title>MooVit - Your Cargo, Our Priority</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
@@ -46,7 +46,7 @@
             <circle cx="5.5" cy="18.5" r="2.5"></circle>
             <circle cx="18.5" cy="18.5" r="2.5"></circle>
           </svg></span>
-        <span class="logo-text">Transport<span class="highlight">Co.</span></span>
+        <span class="logo-text">Moo<span class="highlight">Vit</span></span>
       </a>
       <nav class="desktop-nav">
         <ul class="nav-links">
@@ -161,7 +161,7 @@
   <!-- ABOUT SUMMARY (embedded for smoother homepage flow) -->
   <section id="about" class="about-section">
     <div class="about-container">
-      <h2 class="section-title">About TransportCo</h2>
+      <h2 class="section-title">About MooVit</h2>
       <p class="section-subtitle">We move goods with precision and care — combining modern logistics technology with human-first service to keep your business moving.</p>
 
       <div class="about-grid">
@@ -359,7 +359,7 @@
   <footer class="loading">
     <div class="footer-container">
       <div class="footer-about">
-        <h3>Transport Co.</h3>
+        <h3>MooVit</h3>
         <p>Your trusted logistics partner — ensuring safe, fast, and reliable delivery every time with innovative
           solutions and unmatched customer service excellence across the globe.</p>
       </div>
@@ -452,7 +452,7 @@
       <a href="cookie.html">Cookie</a>
     </div>
     <div class="footer-bottom">
-      <p>&copy; 2025 Transport Co. | All Rights Reserved. | Designed with ❤️ for Excellence</p>
+      <p>&copy; 2025 MooVit | All Rights Reserved. | Designed with ❤️ for Excellence</p>
     </div>
   </footer>
 

--- a/login.html
+++ b/login.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.png">
-  <title>Login - Transport Co.</title>
+  <title>Login - MooVit</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="favicon.png" />
-    <title>Privacy Policy | MoveIt</title>
+    <title>Privacy Policy | MooVit</title>
     <style>
       /* Global Styles */
       * {
@@ -166,14 +166,14 @@
       <div class="back-btn">
         <a href="index.html">&#8592; Back</a>
       </div>
-      <div class="logo">MoveIt</div>
+      <div class="logo">MooVit</div>
     </nav>
 
     <!-- Hero -->
     <section class="hero">
       <div class="hero-content">
         <h1>Privacy Policy</h1>
-        <p>How MoveIt protects your data and respects your rights.</p>
+        <p>How MooVit protects your data and respects your rights.</p>
       </div>
     </section>
 
@@ -181,7 +181,7 @@
     <section class="privacy">
       <h2>Our Commitment to Privacy</h2>
       <p>
-        At <b>MoveIt</b>, your trust is our priority. We are committed to
+        At <b>MooVit</b>, your trust is our priority. We are committed to
         protecting your personal data while ensuring transparency and safety in
         how we use it.
       </p>
@@ -241,7 +241,7 @@
 
     <!-- Footer -->
     <footer>
-      <p>© 2025 MoveIt. All Rights Reserved.</p>
+      <p>© 2025 MooVit. All Rights Reserved.</p>
     </footer>
   </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="favicon.png">
-  <title>Register - Transport Co.</title>
+  <title>Register - MooVit</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -130,7 +130,7 @@
 <body>
   <div class="auth-container">
     <form id="register-form">
-      <h2>Sign Up at Transport Co.</h2>
+      <h2>Sign Up at MooVit</h2>
       <label>Name
         <input type="text" name="name" id="name" placeholder="Your full name" required>
       </label>

--- a/terms.html
+++ b/terms.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="favicon.png" />
-  <title>Terms & Conditions | MoveIt</title>
+  <title>Terms & Conditions | MooVit</title>
   <!-- COPY SAME STYLE BLOCK FROM privacy.html -->
       <style>
       /* Global Styles */
@@ -167,7 +167,7 @@
   <div class="back-btn">
     <a href="index.html">&#8592; Back</a>
   </div>
-  <div class="logo">MoveIt</div>
+  <div class="logo">MooVit</div>
 </nav>
 
 <section class="hero">
@@ -180,7 +180,7 @@
 <section class="privacy">
   <h2>Terms of Service</h2>
   <p>
-    By accessing and using <b>MoveIt</b>, you agree to be legally bound by the following
+    By accessing and using <b>MooVit</b>, you agree to be legally bound by the following
     terms and conditions. Please read them carefully.
   </p>
 
@@ -211,7 +211,7 @@
   <div class="policy-section">
     <h3>4. Limitation of Liability</h3>
     <p>
-      MoveIt is not liable for delays caused by weather, natural disasters, strikes,
+      MooVit is not liable for delays caused by weather, natural disasters, strikes,
       or other circumstances beyond our control.
     </p>
   </div>
@@ -228,7 +228,7 @@
     <h3>6. Intellectual Property</h3>
     <p>
       All website content including branding, design, and logos are the intellectual
-      property of MoveIt and may not be reused without permission.
+      property of MooVit and may not be reused without permission.
     </p>
   </div>
 
@@ -237,7 +237,7 @@
 
 
 <footer>
-  <p>© 2025 MoveIt. All Rights Reserved.</p>
+  <p>© 2025 MooVit. All Rights Reserved.</p>
 </footer>
 
 </body>


### PR DESCRIPTION
## Fixes #866 

### Summary

This PR standardizes remaining legacy branding references across the project by replacing outdated branding with the correct **MooVit** branding.

### Changes Made

* Replaced remaining `Transport Co.` references with `MooVit`
* Standardized legacy `TransportCo`, `MoveIt`, and inconsistent `Moovit` references to `MooVit`
* Updated branding text in page titles, footers, and other branding-related locations

### Verification

* Branding consistency verified across affected pages
* No functionality changes
* No styling or layout changes
* No routing or business logic modifications
