### PR TITLE
fix: remove duplicate modal function definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,53 +524,12 @@
       document.body.style.overflow = menu.classList.contains('active') ? 'hidden' : 'auto';
     });
 
-    // --- Modal Logic ---
-    function closeAllModals() {
-      document.getElementById('overlay').classList.remove('active');
-      document.querySelectorAll('.service-alert, .login-modal, .signup-modal, .admin-modal').forEach(el => el.classList.remove('active'));
-      document.body.style.overflow = 'auto';
-    }
-    function handleServiceClick() {
-      document.getElementById('overlay').classList.add('active');
-      document.getElementById('serviceAlert').classList.add('active');
-      document.body.style.overflow = 'hidden';
-    }
-    function closeServiceAlert() { closeAllModals(); }
-
-    function openLoginPopup(event) {
-      if (event) event.preventDefault();
-
-  closeAllModals();
-
-  document.getElementById('overlay').classList.add('active');
-  document.getElementById('loginModal').classList.add('active');
-
-  document.body.style.overflow = 'hidden';
-    }
-    function closeLoginPopup() { closeAllModals(); }
-
-    function openSignupPopup(event) {
-      if (event) event.preventDefault();
-      closeAllModals();
-      document.getElementById('overlay').classList.add('active');
-      document.getElementById('signupModal').classList.add('active');
-      document.body.style.overflow = 'hidden';
-    }
-
-    function openAdminPopup(event) {
-      if (event) event.preventDefault();
-      closeAllModals();
-      document.getElementById('overlay').classList.add('active');
-      document.getElementById('adminModal').classList.add('active');
-      document.body.style.overflow = 'hidden';
-    }
-
     // --- Backend Form Handling ---
     document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') {
-    closeAllModals();
-  }
-});
+      if (e.key === 'Escape') {
+        window.closeAllModals();
+      }
+    });
 
     // Login Validation
     const loginForm = document.getElementById('login-form-popup');
@@ -622,8 +581,8 @@
         submitBtn.textContent = 'Creating Account...';
         submitBtn.disabled = true;
         setTimeout(() => {
-          closeAllModals();
-          openLoginPopup();
+          window.closeAllModals();
+          window.openLoginPopup();
           document.getElementById('popup-error-msg').style.color = '#10b981';
           document.getElementById('popup-error-msg').textContent = 'Account created!';
         }, 1500);
@@ -643,7 +602,7 @@
           const submitBtn = this.querySelector('.admin-submit-btn');
           submitBtn.textContent = 'Accessing...';
           submitBtn.disabled = true;
-          setTimeout(() => { alert('Access Granted'); closeAllModals(); }, 1000);
+          setTimeout(() => { alert('Access Granted'); window.closeAllModals(); }, 1000);
         } else {
           errorMsg.textContent = 'Invalid Admin credentials.';
         }


### PR DESCRIPTION
## Description

Closes #942

### Summary

This PR removes the duplicate modal function definitions from `index.html` and keeps the centralized `window.*` implementation as the single source of truth.

### Changes Made

- Removed duplicate modal function definitions:
  - `closeAllModals`
  - `handleServiceClick`
  - `closeServiceAlert`
  - `openLoginPopup`
  - `closeLoginPopup`
  - `openSignupPopup`
  - `openAdminPopup`
- Retained the centralized `window.*` implementation.
- Updated remaining references to use the centralized modal API.
- No functional behavior changes were introduced.

### Why

Previously, the same modal functions were defined twice in `index.html`. The later `window.*` implementation overwrote the earlier one at runtime, creating duplicate sources of truth and making maintenance harder.

This change removes the redundant implementation while preserving the existing behavior.

### Testing

- ✅ Login modal opens/closes correctly.
- ✅ Signup modal opens/closes correctly.
- ✅ Admin modal opens/closes correctly.
- ✅ Service alert modal works correctly.
- ✅ Escape key closes active modals.
- ✅ Existing modal behavior remains unchanged.