### PR TITLE
fix: reduce excessive whitespace between navbar and hero section on desktop

### DIFF
--- a/transport.css
+++ b/transport.css
@@ -455,7 +455,7 @@ a, button, input, .card {
     /* --- Hero Section --- */
     .hero {
       max-width: 1400px;
-      margin: 8rem auto 4rem;
+      margin: 5rem auto 4rem;
       padding: 5rem 2rem;
       background: var(--panel-bg);
       border: 1px solid var(--panel-border);


### PR DESCRIPTION
## Summary

This PR fixes the excessive whitespace between the fixed navbar and the hero section on desktop screens.

## Changes

- Reduced the desktop top margin of the `.hero` container from `8rem` to `5rem`.
- Preserved the existing hero padding and layout.
- Left mobile behavior unchanged.

## Testing

- Verified the hero section sits closer to the fixed navbar on desktop.
- Confirmed the layout remains responsive.
- Ran `git diff --check` successfully.

Fixes #956